### PR TITLE
fix: read snake_case likes/views/background fields

### DIFF
--- a/app/_page/HomeContentWrapper.tsx
+++ b/app/_page/HomeContentWrapper.tsx
@@ -43,6 +43,7 @@ export default function HomeContentWrapper() {
       () => data?.data?.originals || [],
       [data?.data?.originals]
     );
+    console.log("@@originalsData", originalsData)
 
   return (
     <div><HomeCarousel carouselData={carouselData}

--- a/app/_page/homeCarousel.tsx
+++ b/app/_page/homeCarousel.tsx
@@ -165,9 +165,9 @@ function HomeCarousel(
             className="absolute inset-0 "
             style={{
               backgroundImage:
-                hoverIndex !== -1 && carouselItems[hoverIndex]?.backgroundImage
-                  ? `url(${carouselItems[hoverIndex]?.backgroundImage})`
-                  : `url(${carouselItems[currentSlide]?.backgroundImage})`,
+                hoverIndex !== -1 && carouselItems[hoverIndex]?.background_image
+                  ? `url(${carouselItems[hoverIndex]?.background_image})`
+                  : `url(${carouselItems[currentSlide]?.background_image})`,
               backgroundSize: "cover",
               backgroundPosition: "center",
               filter: "blur(2px)",

--- a/app/_page/trending.tsx
+++ b/app/_page/trending.tsx
@@ -59,6 +59,7 @@ const Trending = ({trendingData, isLoading}:{trendingData: Comic[], isLoading: b
                         cardData={item}
                         index={i}
                         queryKey={trendingQueryKey}
+                        
 
                       />
                     </div>

--- a/app/_shared/cards/cardTitleOutside.tsx
+++ b/app/_shared/cards/cardTitleOutside.tsx
@@ -16,8 +16,16 @@ const CardTitleOutside = ({
   queryKey?: string;
   noTitle?: boolean;
 }) => {
+  console.log("@@cardData", cardData)
   const views =
-    cardData?.viewsCount ?? 0;
+    cardData?.views_count??cardData?.viewsCount;
+  const likes =
+    cardData?.likes_count??cardData?.likesCount;
+  const favourites =
+    cardData?.favourites_count??cardData?.favouritesCount;
+  const likesAndViews =
+    cardData?.likesAndViews??cardData?.likesAndViews;
+  console.log("@@likesAndViews", likesAndViews)
   return (
     <div>
       <div className="h-[135px] sm:h-[250px] md:h-[320px]  rounded-[4px] overflow-hidden">

--- a/app/trending/_components/trendingItem.tsx
+++ b/app/trending/_components/trendingItem.tsx
@@ -108,6 +108,8 @@ const TrendingItem = ({ data ,refetchTrending}: { data: any,refetchTrending?: an
             queryKey={queryKey}
             uid={data?.uuid}
             favourites={data?.favourites}
+            likesCount={data?.likes_count ?? data?.likesCount}
+            viewsCount={data?.views_count ?? data?.viewsCount}
           />
         </div>
       </Link>

--- a/app/trending/page.tsx
+++ b/app/trending/page.tsx
@@ -83,7 +83,7 @@ export default function Page() {
                         <div className="font-bold text-xl">
                           {newTrending[0]?.title}
                         </div>
-                        <Likes likesNViews={newTrending[0]?.likesAndViews} />
+                        <Likes likesNViews={newTrending[0]?.likesAndViews} likesCount={newTrending[0]?.likes_count ?? newTrending[0]?.likesCount} viewsCount={newTrending[0]?.views_count ?? newTrending[0]?.viewsCount} />
                       </div>
                       <div
                         onClick={(e) => {
@@ -127,7 +127,7 @@ export default function Page() {
                         <div className="font-bold text-xl">
                           {newTrending[1]?.title}
                         </div>
-                        <Likes likesNViews={newTrending[1]?.likesAndViews} />
+                        <Likes likesNViews={newTrending[1]?.likesAndViews} likesCount={newTrending[1]?.likes_count ?? newTrending[1]?.likesCount} viewsCount={newTrending[1]?.views_count ?? newTrending[1]?.viewsCount} />
                       </div>
                       <div
                         onClick={(e) => {
@@ -190,7 +190,7 @@ export default function Page() {
                         width: "100%",
                         maxWidth: "100%",
                         height: "100%",
-                        transform: "rotate(180deg)",
+                        
                       }}
                       priority
                     />
@@ -245,7 +245,7 @@ export default function Page() {
                         <div className="font-bold text-xl">
                           {mostRead[0]?.title}
                         </div>
-                        <Likes likesNViews={mostRead[0]?.likesAndViews} />
+                        <Likes likesNViews={mostRead[0]?.likesAndViews} likesCount={mostRead[0]?.likes_count ?? mostRead[0]?.likesCount} viewsCount={mostRead[0]?.views_count ?? mostRead[0]?.viewsCount} />
                       </div>
                       <div
                         onClick={(e) => {


### PR DESCRIPTION
backend now returns snake_case field names for comic stats and media. read those first, fall back to the camelCase keys so older cached responses keep rendering, and surface counts from new fields where they were previously hardcoded.

read background_image instead of backgroundImage in home carousel hover/slide background add likes_count, views_count, favourites_count fallbacks in CardTitleOutside forward likes_count / views_count to Likes/CardTitleOutside from trending page and TrendingItem drop accidental rotate(180deg) on the trending hero image